### PR TITLE
fix typo in plain dashboard

### DIFF
--- a/dashboards/_plain_dashboard_TypQxQ/dashboard.yaml
+++ b/dashboards/_plain_dashboard_TypQxQ/dashboard.yaml
@@ -433,7 +433,7 @@ views:
           - sensor.sigen_general_alarm2
           - sensor.sigen_general_alarm3
           - sensor.sigen_general_alarm4
-        title: Alam
+        title: Alarm
       - type: entities
         entities:
           - entity: sensor.sigen_plant_pv_power


### PR DESCRIPTION
Title used to be "Alam" but references alarms. Title is now "Alarm"