### PR TITLE
# Fix for Double-Counting in PV Energy Production Sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dashboards/nordpool_energy_chart/test_with_grid.yaml
 .vscode/settings.json
+files_for_debuging/*

--- a/modbus_sigenergy.yaml
+++ b/modbus_sigenergy.yaml
@@ -2431,7 +2431,7 @@ sensor:
     method: trapezoidal
     round: 2
     max_sub_interval:
-      seconds: 5
+      seconds: 30
 
   - platform: integration
     name: Sigen Accumulated PV energy production
@@ -2440,7 +2440,7 @@ sensor:
     method: trapezoidal
     round: 2
     max_sub_interval:
-      seconds: 5
+      seconds: 30
 
   - platform: integration
     name: Sigen Accumulated Grid energy export
@@ -2449,7 +2449,7 @@ sensor:
     method: trapezoidal
     round: 2
     max_sub_interval:
-      seconds: 5
+      seconds: 30
 
   - platform: integration
     name: Sigen Accumulated Grid energy import
@@ -2458,7 +2458,7 @@ sensor:
     method: trapezoidal
     round: 2
     max_sub_interval:
-      seconds: 5
+      seconds: 30
 
   - platform: integration
     name: Sigen Accumulated Inverter energy usage
@@ -2467,7 +2467,7 @@ sensor:
     method: trapezoidal
     round: 2
     max_sub_interval:
-      seconds: 5
+      seconds: 30
 
 utility_meter:
   sigen_daily_energy_consumption:


### PR DESCRIPTION

## The Problem

The `max_sub_interval: seconds: 5` setting in your integration sensors is causing the energy calculation to happen too frequently compared to the actual source sensor updates:

1. Your `sensor.sigen_pv_power` updates approximately every 10-20 seconds
2. With `max_sub_interval: seconds: 5`, the integration platform creates extra calculations between these updates
3. This leads to counting the same energy production multiple times

## The Solution

Update your configuration by changing all `max_sub_interval` settings from 5 seconds to 30 seconds:

```yaml
  - platform: integration
    name: Sigen Accumulated energy consumption
    unique_id: sigen_accumulated_energy_consumption
    source: sensor.sigen_consumed_power
    method: trapezoidal
    round: 2
    max_sub_interval:
      seconds: 30
```

Make this same change for all five integration sensors in your configuration.

## Why This Works

The integration platform uses the `max_sub_interval` setting to determine how to handle gaps between sensor readings:

1. When set too low (like 5 seconds), it creates artificial readings between actual sensor updates
2. When your actual sensor updates less frequently (10-20 seconds), it double-counts energy
3. Setting `max_sub_interval: seconds: 30` ensures calculations only happen on actual sensor updates

This change will provide an accurate energy calculation without the artificial doubling effect.